### PR TITLE
Major Improvements

### DIFF
--- a/BetterQuestObjectivesPatcher/Program.cs
+++ b/BetterQuestObjectivesPatcher/Program.cs
@@ -18,7 +18,8 @@ namespace BetterQuestObjectivesPatcher
             "Dawnguard.esm",
             "HearthFires.esm",
             "Dragonborn.esm",
-            "unofficial skyrim special edition patch.esp" // Requiem has this as a master
+            "unofficial skyrim special edition patch.esp", // Requiem has this as a master
+            "Unofficial Skyrim Special Edition Patch.esp" // in case using old version of ussep with capitals in filename
         };
 
         public static async Task<int> Main(string[] args)

--- a/BetterQuestObjectivesPatcher/Program.cs
+++ b/BetterQuestObjectivesPatcher/Program.cs
@@ -88,13 +88,9 @@ namespace BetterQuestObjectivesPatcher
                         return baseTexts.Contains(o.DisplayText?.String?.ToLower()) ||
                         Equals(o.DisplayText?.String?.ToLower(), bqoObjective.DisplayText?.String?.ToLower());
                     });
-                    /* find closest objective in winner to current objective in BQO by index
-                       reason: in case mod author changes index, example: AYOP - Companions
-                       hopefully this doesn't cause problematic patches if a mod author adds other quest objectives with ambiguous descriptions
-                       ideal solution is matchingObjectives.FirstOrDefault(o => o.Index == bqoObjective.Index) to get exact match with a continue for null case
-                       the same logic may be needed for stages below, but currently there are no known cases */
-                    if (!matchingObjectives.Any()) continue;
-                    var winningObjective = matchingObjectives.Aggregate((closest, next) => Math.Abs(next.Index - bqoObjective.Index) < Math.Abs(closest.Index - bqoObjective.Index) ? next : closest);
+                    // find objective with index that matches BQO
+                    var winningObjective = matchingObjectives.FirstOrDefault(s => s.Index == bqoObjective.Index);
+                    if (winningObjective == null) continue;
                     // skip if winner identical to BQO
                     if (Equals(bqoObjective.DisplayText, winningObjective.DisplayText)) continue;
 

--- a/BetterQuestObjectivesPatcher/Program.cs
+++ b/BetterQuestObjectivesPatcher/Program.cs
@@ -18,9 +18,9 @@ namespace BetterQuestObjectivesPatcher
             "Dawnguard.esm",
             "HearthFires.esm",
             "Dragonborn.esm",
-            "Unofficial Skyrim Special Edition Patch" // Requiem has this as a master
+            "unofficial skyrim special edition patch.esp" // Requiem has this as a master
         };
-        
+
         public static async Task<int> Main(string[] args)
         {
             return await SynthesisPipeline.Instance
@@ -33,13 +33,13 @@ namespace BetterQuestObjectivesPatcher
         {
 
             // var bqoMod = state.LoadOrder.GetIfEnabledAndExists(BQO_ESP);
-            
+
             var quests = state
                 .LoadOrder
                 .PriorityOrder
                 .Quest()
                 .WinningContextOverrides();
-            
+
             foreach (var questCtx in quests)
             {
                 Console.WriteLine($"Processing mod ${questCtx.ModKey.FileName}");
@@ -51,78 +51,84 @@ namespace BetterQuestObjectivesPatcher
 
                 var questLinkGetter = questCtx.Record.ToLinkGetter();
                 var allContexts = questLinkGetter.ResolveAllContexts<ISkyrimMod, ISkyrimModGetter, IQuest, IQuestGetter>(state.LinkCache);
-                
+
                 // Resolve context for quest
                 // Make sure quest has the following in its context:
                 // 1. an entry in a base ESP
                 // 2. an entry in BQO or one of its patches
                 // 3. something else overwriting BQO
-                IModContext<ISkyrimMod,ISkyrimModGetter,IQuest,IQuestGetter> baseGameContext;
-                IModContext<ISkyrimMod,ISkyrimModGetter,IQuest,IQuestGetter> bqoContext;
+                IEnumerable<IModContext<ISkyrimMod, ISkyrimModGetter, IQuest, IQuestGetter>> baseGameContexts = allContexts.Where(context => IsBasicMaster(context.ModKey));
+                if (!baseGameContexts.Any()) continue;
+                IModContext<ISkyrimMod, ISkyrimModGetter, IQuest, IQuestGetter> bqoContext;
                 // third mod context is questCtx
 
-                var modContexts = allContexts.ToList();
                 try
                 {
-                    baseGameContext = modContexts.First(context => IsBasicMaster(context.ModKey));
+                    bqoContext = allContexts.First(context => IsBqoPatch(state.LoadOrder.GetIfEnabled(context.ModKey).Mod!));
                 }
                 catch (InvalidOperationException e)
                 {
                     continue;
                 }
 
-                try
-                {
-                    bqoContext = modContexts.First(context =>
-                    {
-                        var modInContextListing = state.LoadOrder.GetIfEnabled(context.ModKey);
-                        return IsBqoPatch(modInContextListing.Mod!);
-                    });
-                }
-                catch (InvalidOperationException e)
-                {
-                    continue;
-                }
-                
+
+                IQuest? patchedQuest = null;
 
                 var winningObjectives = questCtx.Record.Objectives;
-                var baseObjectives = baseGameContext.Record.Objectives;
+                var allBaseObjectives = baseGameContexts.Select(context => context.Record.Objectives);
                 var bqoObjectives = bqoContext.Record.Objectives;
-
-                if (winningObjectives.Count != baseObjectives.Count || winningObjectives.Count != bqoObjectives.Count)
+                // only iterate through objectives modified by BQO
+                foreach (var bqoObjective in bqoObjectives)
                 {
-                    continue;
+                    // get all versions of text from the base ignoring capitalization (BQO should overwrite text that matches any base)
+                    var baseTexts = allBaseObjectives.SelectMany(objectives => objectives.Where(o => o.Index == bqoObjective.Index).Select(o => o.DisplayText?.String?.ToLower()));
+                    // find all objectives in winner that match a base or BQO (ignoring capitalization)
+                    var matchingObjectives = winningObjectives.Where(o =>
+                    {
+                        return baseTexts.Contains(o.DisplayText?.String?.ToLower()) ||
+                        Equals(o.DisplayText?.String?.ToLower(), bqoObjective.DisplayText?.String?.ToLower());
+                    });
+                    /* find closest objective in winner to current objective in BQO by index
+                       reason: in case mod author changes index, example: AYOP - Companions
+                       hopefully this doesn't cause problematic patches if a mod author adds other quest objectives with ambiguous descriptions
+                       ideal solution is matchingObjectives.FirstOrDefault(o => o.Index == bqoObjective.Index) to get exact match with a continue for null case
+                       the same logic may be needed for stages below, but currently there are no known cases */
+                    if (!matchingObjectives.Any()) continue;
+                    var winningObjective = matchingObjectives.Aggregate((closest, next) => Math.Abs(next.Index - bqoObjective.Index) < Math.Abs(closest.Index - bqoObjective.Index) ? next : closest);
+                    // skip if winner identical to BQO
+                    if (Equals(bqoObjective.DisplayText, winningObjective.DisplayText)) continue;
+
+                    patchedQuest ??= questCtx.GetOrAddAsOverride(state.PatchMod);
+                    patchedQuest.Objectives.Where(o => o.Index == winningObjective.Index).First().DisplayText = bqoObjective.DisplayText!.DeepCopy();
                 }
-                
-                // If those 3 things are true
-                // For each quest obective
-                // TODO: Clean up this nasty CS101 loop
-                var copiedAsOverride = false;
-                IQuest? patchedQuest = null;
-                for (var i = 0; i < winningObjectives.Count; i++)
-                {
-                    // If NNAM of winning override == NNAM of basic master (skyrim, dg, etc)
-                    if (!Equals(winningObjectives[i].DisplayText!.String, baseObjectives[i].DisplayText!.String))
-                    {
-                        continue;
-                    }
-                    // AND if NNAM is different in bqo
-                    if (Equals(bqoObjectives[i].DisplayText!.String, winningObjectives[i].DisplayText!.String)) continue;
-                    // Bail out if any null
-                    if (winningObjectives[i].DisplayText == null || bqoObjectives[i].DisplayText == null || baseObjectives[i].DisplayText == null)
-                    {
-                        continue;
-                    }
-                            
-                    if (!copiedAsOverride)
-                    {
-                        patchedQuest = questCtx.GetOrAddAsOverride(state.PatchMod);
-                        copiedAsOverride = true;
-                    }
 
-                    if (patchedQuest != null)
+                // patch Log Entries for Stages
+                var winningStages = questCtx.Record.Stages;
+                var allBaseStages = baseGameContexts.Select(context => context.Record.Stages);
+                var bqoStages = bqoContext.Record.Stages;
+                // only iterate through stages modified by BQO
+                foreach (var bqoStage in bqoStages)
+                {
+                    var baseStages = allBaseStages.SelectMany(stages => stages.Where(s => s.Index == bqoStage.Index));
+                    // iterate over each log entry that appears in the BQO version
+                    for (var i = 0; i < bqoStage.LogEntries.Count; i++)
                     {
-                        patchedQuest.Objectives[i].DisplayText = bqoObjectives[i].DisplayText!.DeepCopy();
+                        // get all versions of text from the base ignoring capitalization (BQO should overwrite text that matches any base)
+                        var baseTexts = baseStages.Where(s => i < s.LogEntries.Count).Select(s => s.LogEntries[i].Entry?.String?.ToLower());
+                        // find all objectives in winner that match a base or BQO (ignoring capitalization)
+                        var matchingStages = winningStages.Where(s =>
+                        {
+                            return baseTexts.Contains(s.LogEntries.ElementAtOrDefault(i)?.Entry?.String?.ToLower()) ||
+                            Equals(s.LogEntries.ElementAtOrDefault(i)?.Entry?.String?.ToLower(), bqoStage.LogEntries[i].Entry?.String?.ToLower());
+                        });
+                        // find stage with index that matches BQO
+                        var winningStage = matchingStages.FirstOrDefault(s => s.Index == bqoStage.Index);
+                        if (winningStage == null) continue;
+                        // skip if winner identical to BQO
+                        if (Equals(bqoStage.LogEntries[i].Entry, winningStage.LogEntries[i].Entry)) continue;
+
+                        patchedQuest ??= questCtx.GetOrAddAsOverride(state.PatchMod);
+                        patchedQuest.Stages.Where(s => s.Index == winningStage.Index).First().LogEntries[i].Entry = bqoStage.LogEntries[i].Entry!.DeepCopy();
                     }
                 }
             }
@@ -133,7 +139,7 @@ namespace BetterQuestObjectivesPatcher
             return mod.ModKey.FileName.Equals(BqoEsp)
                    || mod.MasterReferences.Any(reference => reference.Master.FileName.Equals(BqoEsp));
         }
-        
+
         private static bool IsBasicMaster(ModKey mod)
         {
             return BasicMasters.Contains(mod.FileName);


### PR DESCRIPTION
This PR improves patching in multiple ways:
1. Improves the matching for objectives of BQO and other mods by using the objective index contained in the plugin records instead of an array index
2. Adds patching Log Entries for Stages of quests
3. Allows overwriting any string that copies from any of the base versions (e.g. USSEP makes some grammatical fixes, but not all mods copy the USSEP version of a string)
4. Fixes the USSEP check in the base masters

The first commit contains a workaround for patching AYOP - Companions which seems to erroneously change an objective index in a quest. The solution I came up with is to match on the closest objective index from BQO instead of requiring an exact match. However, the EBQO SE modpage now has a patch for AYOP - Companions that makes this hack unnecessary. Thus, I've removed it since it could have unintended consequences and this is the only case I found where this happens. Should another case be discovered, that logic is available in the history.